### PR TITLE
More chart options

### DIFF
--- a/charts/sshpiper/templates/_helpers.tpl
+++ b/charts/sshpiper/templates/_helpers.tpl
@@ -49,3 +49,15 @@ Selector labels
 app.kubernetes.io/name: {{ include "sshpiper.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sshpiper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- $name := printf "%s-reader" (include "sshpiper.fullname" .) }}
+{{- default $name .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/sshpiper/templates/deployment.yaml
+++ b/charts/sshpiper/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
       {{- include "sshpiper.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "sshpiper.selectorLabels" . | nindent 8 }}
     spec:
@@ -18,11 +22,15 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "sshpiper.fullname" . }}-reader
+      serviceAccountName: {{ include "sshpiper.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: sshpiper
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         ports:
           - containerPort: 2222
         env:
@@ -31,11 +39,25 @@ spec:
         - name: SSHPIPERD_SERVER_KEY
           value: "/serverkey/ssh_host_key"
         - name: SSHPIPERD_LOG_LEVEL
-          value: {{ .Values.sshpiper.loglevel }}
+          value: {{ .Values.sshpiper.loglevel | quote }}
+        {{- if .Values.sshpiper.bannertext }}
+        - name: SSHPIPERD_BANNERTEXT
+          value: {{ .Values.sshpiper.bannertext | quote }}
+        {{- end }}
+        {{- if .Values.sshpiper.login_grace_time }}
+        - name: SSHPIPERD_LOGIN_GRACE_TIME
+          value: {{ .Values.sshpiper.login_grace_time | quote }}
+        {{- end }}
+        {{- if .Values.sshpiper.kubernetes_all_namespaces }}
+        - name: SSHPIPERD_KUBERNETES_ALL_NAMESPACES
+          value: "true"
+        {{- end }}
         volumeMounts:
         - name: sshpiper-server-key
           mountPath: "/serverkey/"
-          readOnly: true          
+          readOnly: true
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
       volumes:
       - name: sshpiper-server-key
         secret:
@@ -43,4 +65,15 @@ spec:
           items:
           - key: server_key
             path: ssh_host_key
-
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sshpiper/templates/role.yaml
+++ b/charts/sshpiper/templates/role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.create }}
+{{- if and .Values.sshpiper.kubernetes_all_namespaces (not .Values.rbac.clusterRole) }}
+{{- fail "sshpiper watches all namespaces, but rbac.clusterRole not enabled" }}
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.clusterRole }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
+metadata:
+  name: {{ include "sshpiper.fullname" . }}
+  labels:
+    {{- include "sshpiper.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - sshpiper.com
+  resources:
+  - pipes
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/sshpiper/templates/rolebinding.yaml
+++ b/charts/sshpiper/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.clusterRole }}
+kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
+metadata:
+  name: {{ include "sshpiper.fullname" . }}
+  labels:
+    {{- include "sshpiper.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.clusterRole }}
+  kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
+  name: {{ include "sshpiper.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sshpiper.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/sshpiper/templates/secret.yaml
+++ b/charts/sshpiper/templates/secret.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
-data:
-  {{- if .Values.sshpiper.ssh_host_key }}
-  server_key: {{ .Values.sshpiper.ssh_host_key }}
-  {{- else }}
-  server_key: "{{genPrivateKey "ecdsa" | b64enc}}"
-  {{- end }}
 kind: Secret
 metadata:
   name: {{ include "sshpiper.fullname" . }}-server-key
+  labels:
+    {{- include "sshpiper.labels" . | nindent 4 }}
 type: Opaque
+data:
+  {{- if .Values.sshpiper.ssh_host_key_base64 }}
+  server_key: {{ .Values.sshpiper.ssh_host_key_base64 | quote }}
+  {{- else }}
+  server_key: "{{genPrivateKey "ecdsa" | b64enc}}"
+  {{- end }}

--- a/charts/sshpiper/templates/service.yaml
+++ b/charts/sshpiper/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "sshpiper.fullname" . }}
   labels:
     {{- include "sshpiper.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/sshpiper/templates/serviceaccount.yaml
+++ b/charts/sshpiper/templates/serviceaccount.yaml
@@ -1,33 +1,12 @@
-{{- $serviceName := include "sshpiper.fullname" . -}}
-
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $serviceName }}-reader
+  name: {{ include "sshpiper.serviceAccountName" . }}
   labels:
     {{- include "sshpiper.labels" . | nindent 4 }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ $serviceName }}-reader
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get"]
-- apiGroups: ["sshpiper.com"]
-  resources: ["pipes"]
-  verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ $serviceName }}-reader
-subjects:
-- kind: ServiceAccount
-  name: {{ $serviceName }}-reader
-roleRef:
-  kind: Role
-  name: {{ $serviceName }}-reader
-  apiGroup: rbac.authorization.k8s.io
----
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sshpiper/values.yaml
+++ b/charts/sshpiper/values.yaml
@@ -6,7 +6,10 @@ replicaCount: 1
 
 sshpiper:
   loglevel: "info"
-  ssh_host_key: "" # This is the private key of the ssh server. It is generated if not set.
+  ssh_host_key_base64: "" # This is the private key of the ssh server. It is generated if not set.
+  login_grace_time: 30s
+  bannertext: ""
+  kubernetes_all_namespaces: false
 
 image:
   repository: farmer1992/sshpiperd
@@ -18,6 +21,51 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+rbac:
+  create: true
+  clusterRole: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsGroup: 65534
+  runAsUser: 65534
+
 service:
   type: ClusterIP
   port: 2222
+  annotations: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
I was working on chart to contribute last week, but you are so unbelievably quick and came with your own :). So, at least I'm contributing some my parts directly to your chart, in case you are interested (also can update up to your preferences). Thank you for the hard work!

Improved:
- more sshpiper options (also better UX is not to require `sshpiper.ssh_host_key` to be base64 encoded by chart user)
- default security context using unprivileged user (not necessary to use root and all capabilities)
- RBAC for selectable Role (default) or ClusterRole

Other common options:
- placement (pod affinity, tolerations, nodeSelector) and resources
- service annotations (to be able to configure LBs)
- service account options

Related to https://github.com/tg123/sshpiper/issues/118