### PR TITLE
Release Helm chart with sshpiper 1.5.0

### DIFF
--- a/charts/sshpiper/Chart.yaml
+++ b/charts/sshpiper/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sshpiper
 description: The missing reverse proxy for ssh scp, username based SSH Reverse Proxy 
 type: application
-version: 0.4.5
-appVersion: "v1.4.6"
+version: 0.4.6
+appVersion: "v1.5.0"
 
 sources:
   - https://github.com/tg123/sshpiper


### PR DESCRIPTION
Not sure if there is some issue with sshpiper 1.5.0, but there was no new Helm chart release for this version (although user can update image tag directly via `image.tag` Helm value if really needed). If there is some issue with chart with this sshpiper version, I'm happy to help. But, so far it works for me as it is (but I'm using a full image).