### PR TITLE
Add a hostPort option

### DIFF
--- a/charts/sshpiper/templates/deployment.yaml
+++ b/charts/sshpiper/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
           {{- toYaml .Values.securityContext | nindent 10 }}
         ports:
           - containerPort: 2222
+            {{- if .Values.service.hostPort }}
+            hostPort: {{ .Values.service.hostPort }}
+            {{- end }}
         env:
         {{- if .Values.sshpiper.failtoban.enabled }}
         - name: SSHPIPERD_FAILTOBAN_MAX_FAILURES

--- a/charts/sshpiper/values.yaml
+++ b/charts/sshpiper/values.yaml
@@ -57,6 +57,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 2222
+  # hostPort: 22
   annotations: {}
 
 resources: {}


### PR DESCRIPTION
I'm still new to k8s, so please let me know if i'm missing something obvious here :)

This option lets you directly expose sshpiper to the port on the node it's running on. I believe it makes fail2ban more useful, because without this option fail2ban can see only your cluster IPs, right?